### PR TITLE
Avoids having to reverse the list of providers

### DIFF
--- a/lib/krypt/provider/provider.rb
+++ b/lib/krypt/provider/provider.rb
@@ -13,7 +13,7 @@ module Krypt::Provider
       name ||= provider.name
       raise AlreadyExistsError.new("There already is a Provider named #{name}") if PROVIDERS.has_key?(name)
       PROVIDERS[name] = provider
-      PROVIDER_LIST << name
+      PROVIDER_LIST.unshift(name)
     end
 
     def by_name(name)
@@ -27,7 +27,7 @@ module Krypt::Provider
     end
 
     def new_service(klass, *args)
-      PROVIDER_LIST.reverse.each do |name| 
+      PROVIDER_LIST.each do |name| 
         service = PROVIDERS[name].new_service(klass, *args)
         return service if service
       end


### PR DESCRIPTION
When registering a provider it appends it to the list of providers.

When creating a new service, since it finds from most recent registered to oldest currently the list needs to be reversed. This avoids it.
