### PR TITLE
just warn on missing FFI support when jruby fails to load FFI 

### DIFF
--- a/lib/krypt/provider.rb
+++ b/lib/krypt/provider.rb
@@ -20,6 +20,8 @@ begin
 rescue LoadError => e
   if java? && native_disabled?
     # Do not use the FFI provider with JRuby and native API access disabled
+  elsif java?
+    warn "FFI support not available for #{RUBY_PLATFORM}"
   else
     raise e
   end

--- a/lib/krypt/provider.rb
+++ b/lib/krypt/provider.rb
@@ -1,8 +1,7 @@
 require_relative 'provider/provider'
 
 ##
-# If JRuby is configured with native API access disabled, requiring the FFI
-# provider will result in a LoadError. The FFI provider is not required at
+# For JRuby the FFI provider is not required at
 # runtime as there is always a default (Java-based) provider.
 #
 
@@ -10,19 +9,6 @@ def java?
   !! (RUBY_PLATFORM =~ /java/)
 end
 
-def native_disabled?
-  require 'jruby'
-  !JRuby.runtime.instance_config.native_enabled
-end
-
-begin
+unless java?
   require_relative 'provider/ffi'
-rescue LoadError => e
-  if java? && native_disabled?
-    # Do not use the FFI provider with JRuby and native API access disabled
-  elsif java?
-    warn "FFI support not available for #{RUBY_PLATFORM}"
-  else
-    raise e
-  end
 end


### PR DESCRIPTION
fixes #50

since krypt does work with having native support for JRuby disabled, it also shoud work in case FFI can not be loaded due to various possible reasons. see https://github.com/jruby/jruby/issues/1800

this is just a suggestion on how to fix it. but it would be nice to see a fix for this on the next jruby-1.7.14 release ;)
